### PR TITLE
feat: impl check shiftKey in Editable #659

### DIFF
--- a/packages/chakra-ui/src/Editable/index.js
+++ b/packages/chakra-ui/src/Editable/index.js
@@ -93,7 +93,7 @@ const Editable = forwardRef(
         return;
       }
 
-      if (key === "Enter") {
+      if (key === "Enter" && !event.shiftKey && !event.metaKey) {
         handleSubmit();
       }
     };


### PR DESCRIPTION
Before submitting when the "Enter" key is pressed, check to ensure the shiftKey or metaKey are not pressed. This allows for adding new lines when the editable is a textarea.